### PR TITLE
Add `0.4.0-beta.2` release

### DIFF
--- a/0.4.0-beta.2/config.yml
+++ b/0.4.0-beta.2/config.yml
@@ -1,0 +1,5 @@
+# dbs:
+#  - path: /path/to/primary/db            # Database to replicate from
+#    replicas:
+#      - path: /path/to/replica           # File-based replication
+#      - url:  s3://my.bucket.com/db      # S3-based replication

--- a/0.4.0-beta.2/rockcraft.yaml
+++ b/0.4.0-beta.2/rockcraft.yaml
@@ -1,0 +1,45 @@
+name: litestream
+summary: Litestream in a Rock.
+description: "Litestream is a tool for replicating SQLite databases in real-time."
+version: "0.4.0-beta.2"
+base: ubuntu@24.04
+license: Apache-2.0
+services:
+  litestream:
+    command: /bin/litestream replicate -config /etc/litestream.yml
+    override: replace
+    startup: enabled
+platforms:
+  amd64:
+parts:
+  litestream:
+    plugin: go
+    source: https://github.com/benbjohnson/litestream
+    source-type: git
+    source-tag: "v0.4.0-beta.2"
+    source-depth: 1
+    build-snaps:
+      - go/1.24/stable
+    build-environment:
+      - BUILD_IN_CONTAINER: "false"
+    build-packages:
+      - libsystemd-dev
+    override-build: |
+      go build -ldflags "-s -w -X 'main.Version=latest' -extldflags '-static'" -tags osusergo,netgo,sqlite_omit_load_extension -o $CRAFT_PART_INSTALL/bin/litestream ./cmd/litestream
+    stage:
+      - bin/litestream
+  default-config:
+    plugin: dump
+    source: .
+    organize:
+      config.yml: etc/litestream.yml
+    stage:
+      - etc/litestream.yml
+  deb-security-manifest:
+    plugin: nil
+    after:
+      - litestream
+    override-prime: |
+      set -x
+      mkdir -p $CRAFT_PRIME/usr/share/rocks/
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query

--- a/goss.yaml
+++ b/goss.yaml
@@ -7,3 +7,7 @@ command:
   litestream version:
     exit-status: 0
     stderr: []
+
+process:
+  litestream:
+    running: true


### PR DESCRIPTION
The latest released `0.3.13` has vulnerability issues. The patches for theses vulnerabilities is supposedly included in the `0.4.0-beta.2` tag, whose docker image we've been using in our charms


